### PR TITLE
Add test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,28 @@
   <version>1.3.4</version>
   <packaging>jar</packaging>
   <name>UIC barcode</name>
-  <description>encoding and decoding of bar code content according to UIC IRS 90918-9</description>
+  <description>encoding and decoding of Aztec barcode content according to UIC IRS 90918-9</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.70</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <resources>
@@ -30,6 +51,7 @@
       <plugin>
 		  <groupId>org.apache.maven.plugins</groupId>
 		  <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.0</version>
 		  <executions>
 		    <execution>
 		      <id>attach-sources</id>
@@ -37,20 +59,24 @@
 		        <goal>jar</goal>
 		      </goals>
 		    </execution>
+            <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                    <goal>jar</goal>
+                </goals>
+            </execution>
 		  </executions>
 		</plugin>
-      <plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-source-plugin</artifactId>
-		  <executions>
-		    <execution>
-		       <id>attach-javadocs</id>
-		       <goals>
-		          <goal>jar</goal>
-		       </goals>
-		    </execution>
-		  </executions>
-		</plugin>		
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.7.1</version>
+            <configuration>
+                <locales>en_gb</locales>
+                <outputDirectory>${project.build.directory}/site</outputDirectory>
+                <relativizeDecorationLinks>false</relativizeDecorationLinks>
+            </configuration>
+        </plugin>
     </plugins>
    
   </build>
@@ -59,7 +85,7 @@
   <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
   </licenses>


### PR DESCRIPTION
Address maven build warnings.
Add maven test dependencies, so project can be build once imported into IDE.