### PR TITLE
Address SonarLint java:S2178

### DIFF
--- a/src/main/java/org/uic/barcode/asn1/uper/AsnExtractor.java
+++ b/src/main/java/org/uic/barcode/asn1/uper/AsnExtractor.java
@@ -42,10 +42,10 @@ public class AsnExtractor {
 		
 		if (extractionStarted || extractionCompleted) return false;
 		
-		if (path != null && path.length() > 0 && className != null & className.length() > 0) {
-			if (className.endsWith(path)){
-				return true;
-			}
+		if (path != null && path.length() > 0 &&
+				className != null && className.length() > 0 &&
+				className.endsWith(path)) {
+			return true;
 		}
 		
 		return false;

--- a/src/main/java/org/uic/barcode/asn1/uper/SeqOfCoder.java
+++ b/src/main/java/org/uic/barcode/asn1/uper/SeqOfCoder.java
@@ -29,7 +29,7 @@ class SeqOfCoder implements Decoder, Encoder {
 
         //CG pass annotations too each field encoding
         Annotation[] annotationArray = new Annotation[] {};
-        if (annotations != null & annotations.getAnnotations() != null && !annotations.getAnnotations().isEmpty()) {
+        if (annotations != null && annotations.getAnnotations() != null && !annotations.getAnnotations().isEmpty()) {
         	ArrayList<Annotation> fieldAnnotations = new ArrayList<Annotation>();
           	fieldAnnotations.addAll(annotations.getAnnotations());
             annotationArray = new Annotation[fieldAnnotations.size()];


### PR DESCRIPTION
Hi Clemens, 
Wahrscheinlich sollte is im Code && heissen und nicht & damit der 2 Ausdruck nur bedingt ausgeführt wird.

The use of non-short-circuit logic in a boolean context is likely a mistake - one that could cause serious program errors as conditions are evaluated under the wrong circumstances.