### PR TITLE
changed 'minValue' for 'productIdNum' from 1 to 0 for FCB 1.x.x;

### DIFF
--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/CarCarriageReservationData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/CarCarriageReservationData.java
@@ -84,7 +84,7 @@ public class CarCarriageReservationData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 10)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 11)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/CountermarkData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/CountermarkData.java
@@ -56,7 +56,7 @@ public class CountermarkData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 5)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/FIPTicketData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/FIPTicketData.java
@@ -58,7 +58,7 @@ public class FIPTicketData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 5)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/IncludedOpenTicketType.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/IncludedOpenTicketType.java
@@ -50,7 +50,7 @@ public class IncludedOpenTicketType extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 2)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 3)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/OpenTicketData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/OpenTicketData.java
@@ -59,7 +59,7 @@ public class OpenTicketData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 5)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/PassData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/PassData.java
@@ -71,7 +71,7 @@ public class PassData extends Object {
 
 	/** The product id num. */
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	/** The product id IA 5. */

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/ReservationData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/ReservationData.java
@@ -69,7 +69,7 @@ public class ReservationData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 7)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 8)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/StationPassageData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/StationPassageData.java
@@ -58,7 +58,7 @@ public class StationPassageData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 5)

--- a/src/main/java/org/uic/barcode/ticket/api/asn/omv1/VoucherData.java
+++ b/src/main/java/org/uic/barcode/ticket/api/asn/omv1/VoucherData.java
@@ -55,7 +55,7 @@ public class VoucherData extends Object {
 	@Asn1Optional public String productOwnerIA5;
 
 	@FieldOrder(order = 4)
-	@IntRange(minValue=1,maxValue=32000)
+	@IntRange(minValue=0,maxValue=32000)
 	@Asn1Optional public Long productIdNum;
 
 	@FieldOrder(order = 5)


### PR DESCRIPTION
According to 'uicRailTicketData_v1.3.4.asn' and others 'minValue' for 'productIdNum' has to be 0. 
Otherwise it causes wrong values during interpretation with software that is not based on this library.

Our test case: Write ticket with 9999 as productIdNum with this library:
- Tested with DB-C-Lib: 9998,
- Tested with eTicketinfo: 9998,
- Tested with [asn1tools](https://pypi.org/project/asn1tools/): 9998,
