### PR TITLE
Fix parsing of tickets with non 0-prefixed length

### DIFF
--- a/src/main/java/org/uic/barcode/staticFrame/StaticFrame.java
+++ b/src/main/java/org/uic/barcode/staticFrame/StaticFrame.java
@@ -504,7 +504,7 @@ public class StaticFrame {
 			throw (new EncodingFormatException(String.format("UIC Barcode Version %s not supported", versionValue)));
 		}
 
-		String lengthValue   = new String( Arrays.copyOfRange(inputData,offset,offset + 4));
+		String lengthValue   = new String( Arrays.copyOfRange(inputData,offset,offset + 4)).trim();
 		offset = offset + 4;		
 		
 		int dataLength = 0;


### PR DESCRIPTION
We discovered some tickets in the wild that use a space-prefixed length, this fixes parsing them.