### PR TITLE
Correct errant space in the ASN.1 definition files

### DIFF
--- a/misc/uicBarcodeHeader_v1.0.0.asn
+++ b/misc/uicBarcodeHeader_v1.0.0.asn
@@ -101,7 +101,7 @@ ASN-Module DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       	level1SigningAlg   OBJECT IDENTIFIER OPTIONAL,
       	level2SigningAlg   OBJECT IDENTIFIER OPTIONAL,
       	
-        level2PublicKey    OCTET  STRING     OPTIONAL
+        level2PublicKey    OCTET STRING     OPTIONAL
 
    }
 

--- a/misc/uicBarcodeHeader_v2.0.0.asn
+++ b/misc/uicBarcodeHeader_v2.0.0.asn
@@ -92,7 +92,7 @@ ASN-Module-Header DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       	-- algorithm used for signing
       	level1SigningAlg   OBJECT IDENTIFIER OPTIONAL,
       	level2SigningAlg   OBJECT IDENTIFIER OPTIONAL,
-        level2PublicKey    OCTET  STRING     OPTIONAL,
+        level2PublicKey    OCTET STRING     OPTIONAL,
         
         -- end of the validity of the bar code, after this date and time the bar code needs to be regenerated 
         -- by the provider of the ticket

--- a/misc/uicBarcodeHeader_v2.0.1.asn
+++ b/misc/uicBarcodeHeader_v2.0.1.asn
@@ -101,7 +101,7 @@ ASN-Module-Header DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       	-- algorithm used for signing
       	level1SigningAlg   OBJECT IDENTIFIER OPTIONAL,
       	level2SigningAlg   OBJECT IDENTIFIER OPTIONAL,
-        level2PublicKey    OCTET  STRING     OPTIONAL,
+        level2PublicKey    OCTET STRING     OPTIONAL,
         
         -- end of the validity of the bar code, after this date and time the bar code needs to be regenerated 
         -- by the provider of the ticket


### PR DESCRIPTION
In the following files:

- `misc/uicBarcodeHeader_v1.0.0.asn`
- `misc/uicBarcodeHeader_v2.0.0.asn`
- `misc/uicBarcodeHeader_v2.0.1.asn`

there were two spaces between `OCTET` and `STRING`. This is, per a strict reading of the ASN.1 specification, not permissible - causing some libraries to fail on it. 

This PR corrects these to `OCTET STRING` instead of `OCTET  STRING`.