### PR TITLE
Add space in ASN1 definitions between type and constraint

### DIFF
--- a/misc/uicBarcodeHeader_v1.0.0.asn
+++ b/misc/uicBarcodeHeader_v1.0.0.asn
@@ -29,7 +29,7 @@ ASN-Module DEFINITIONS AUTOMATIC TAGS ::= BEGIN
 -- #    the format is kept more flexible to cover upcoming extensions of the RICS code by ERA	
 -- #          
 -- # 
--- # -	A bar code which is only static (printed on a paper), and for which the security is in the system, doesn’t need any of these elements.
+-- # -	A bar code which is only static (printed on a paper), and for which the security is in the system, doesnâ€™t need any of these elements.
 -- # -	A bar code which is only static, and includes its own security, needs:
 -- #  	  level1Signature
 -- #      level1KeyAlg if the associated key does not include the complete certificate in keys.xml but only the public key
@@ -81,7 +81,7 @@ ASN-Module DEFINITIONS AUTOMATIC TAGS ::= BEGIN
     	securityProviderNum INTEGER (1..32000) OPTIONAL,				
     	securityProviderIA5 IA5String          OPTIONAL,	
     	
-    	keyId		        INTEGER(0..99999)  OPTIONAL,
+    	keyId		        INTEGER (0..99999)  OPTIONAL,
     	
     	dataSequence 	    SEQUENCE OF DataType,
 

--- a/misc/uicBarcodeHeader_v2.0.1.asn
+++ b/misc/uicBarcodeHeader_v2.0.1.asn
@@ -82,7 +82,7 @@ ASN-Module-Header DEFINITIONS AUTOMATIC TAGS ::= BEGIN
     	securityProviderNum INTEGER (1..32000) OPTIONAL,				
     	securityProviderIA5 IA5String          OPTIONAL,	
     	
-    	keyId		        INTEGER(0..99999)  OPTIONAL,
+    	keyId		        INTEGER (0..99999)  OPTIONAL,
     	
     	dataSequence 	    SEQUENCE OF DataType,
 

--- a/misc/uicRailTicketData_v3.0.3.asn
+++ b/misc/uicRailTicketData_v3.0.3.asn
@@ -2090,9 +2090,9 @@ ASN-Module-RailTicketData DEFINITIONS AUTOMATIC TAGS ::= BEGIN
   -- #####################################################################################    
      LuggageRestrictionType ::= SEQUENCE {
     	 -- allowed hand luggage pieces on this ticket (3 = default in current NRT tariff)
-    	 maxHandLuggagePieces		INTEGER(0..99) 	DEFAULT 3,			
+    	 maxHandLuggagePieces		INTEGER (0..99) 	DEFAULT 3,			
     	 -- allowed hand luggage pieces on this ticket (3 = default in current NRT tariff)    	 
-    	 maxNonHandLuggagePieces	INTEGER(0..99) 	DEFAULT 1,			
+    	 maxNonHandLuggagePieces	INTEGER (0..99) 	DEFAULT 1,			
     	 registeredLuggage			SEQUENCE OF RegisteredLuggageType OPTIONAL
     	 ,...
     	 


### PR DESCRIPTION
I *believe* a space is required, but was not really able to find where it's defined in https://www.ietf.org/rfc/rfc6025.html#section-2.2 , so feel free to reject this PR.