### PR TITLE
Level 2 data type checking

### DIFF
--- a/src/main/java/org/uic/barcode/Encoder.java
+++ b/src/main/java/org/uic/barcode/Encoder.java
@@ -373,10 +373,9 @@ public class Encoder {
 	
 	
 	public IUicDynamicContent getDynamicContent() {
-		if (dynamicFrame != null && dynamicFrame.getLevel2Data() != null) {
-			return dynamicFrame.getDynamicContent();
-		}
-		return null;
+        if (dynamicFrame == null)
+            return null;
+        return dynamicFrame.getDynamicContent();
 	}
 	
 

--- a/src/main/java/org/uic/barcode/dynamicContent/api/DynamicContentCoder.java
+++ b/src/main/java/org/uic/barcode/dynamicContent/api/DynamicContentCoder.java
@@ -7,6 +7,7 @@ import org.uic.barcode.dynamicContent.fdc1.GeoCoordinateType;
 import org.uic.barcode.dynamicContent.fdc1.SequenceOfExtension;
 import org.uic.barcode.dynamicContent.fdc1.TimeStamp;
 import org.uic.barcode.dynamicContent.fdc1.UicDynamicContentDataFDC1;
+import org.uic.barcode.dynamicFrame.Constants;
 import org.uic.barcode.ticket.EncodingFormatException;
 import org.uic.barcode.asn1.uper.UperEncoder;
 import org.uic.barcode.dynamicContent.fdc1.ExtensionData;
@@ -25,12 +26,8 @@ import org.uic.barcode.ticket.api.spec.IHemisphereLongitudeType;
 import org.uic.barcode.ticket.api.utils.UicEncoderUtils;
 
 public class DynamicContentCoder {
-	
-	public static String dynamicContentDataFDC1 = "FDC1";
-	
 	public static byte[] encode(IUicDynamicContent content, String format) throws EncodingFormatException {
-		
-		if (format != null && !format.equals(dynamicContentDataFDC1)) {
+		if (format != null && !format.equals(Constants.DATA_TYPE_FDC_VERSION_1)) {
 			throw new EncodingFormatException("Format of dynamic content not supported!");
 		}
 				
@@ -38,7 +35,7 @@ public class DynamicContentCoder {
 		
 		asn.setAppId(content.getAppId());
 		
-		if (content.getChallengeString() != null && content.getChallengeString().length() > 0) {
+		if (content.getChallengeString() != null && !content.getChallengeString().isEmpty()) {
 			asn.setChallengeString(content.getChallengeString());
 		}
 

--- a/src/main/java/org/uic/barcode/dynamicContent/fdc1/UicDynamicContentDataFDC1.java
+++ b/src/main/java/org/uic/barcode/dynamicContent/fdc1/UicDynamicContentDataFDC1.java
@@ -11,6 +11,7 @@ import org.uic.barcode.asn1.datatypes.HasExtensionMarker;
 import org.uic.barcode.asn1.datatypes.RestrictedString;
 import org.uic.barcode.asn1.datatypes.Sequence;
 import org.uic.barcode.asn1.uper.UperEncoder;
+import org.uic.barcode.dynamicFrame.Constants;
 import org.uic.barcode.dynamicFrame.api.IData;
 import org.uic.barcode.dynamicFrame.api.SimpleData;
 import org.uic.barcode.dynamicFrame.v1.DataType;
@@ -93,7 +94,7 @@ public class UicDynamicContentDataFDC1  {
 	}
 	
 	public static String getFormat() {
-		return "FDC1";
+		return Constants.DATA_TYPE_FDC_VERSION_1;
 	}
 	
 	public IData getApiDataType() {

--- a/src/main/java/org/uic/barcode/dynamicFrame/Constants.java
+++ b/src/main/java/org/uic/barcode/dynamicFrame/Constants.java
@@ -16,8 +16,10 @@ public class Constants {
 	
 	public static String DATA_TYPE_FCB_VERSION_1 = "FCB1";
 	public static String DATA_TYPE_FCB_VERSION_2 = "FCB2";	
-	public static String DATA_TYPE_FCB_VERSION_3 = "FCB3";	
-	
+	public static String DATA_TYPE_FCB_VERSION_3 = "FCB3";
+
+	public static String DATA_TYPE_FDC_VERSION_1 = "FDC1";
+
 	public static String DYNAMIC_BARCODE_FORMAT_DEFAULT = "U1";
 
 	public static int LEVEL2_VALIDATION_OK = 0;	

--- a/src/main/java/org/uic/barcode/dynamicFrame/api/SimpleDynamicFrame.java
+++ b/src/main/java/org/uic/barcode/dynamicFrame/api/SimpleDynamicFrame.java
@@ -223,13 +223,11 @@ public class SimpleDynamicFrame implements IDynamicFrame {
 			sig.update(signedData2);
 		} catch (SignatureException e) {
 			return Constants.LEVEL2_VALIDATION_SIG_ALG_NOT_IMPLEMENTED;
-		} catch (IllegalArgumentException e) {
-			return Constants.LEVEL2_VALIDATION_ENCODING_ERROR;
-		} catch (UnsupportedOperationException e) {
+		} catch (IllegalArgumentException | UnsupportedOperationException e) {
 			return Constants.LEVEL2_VALIDATION_ENCODING_ERROR;
 		}
-		
-		byte[] signature = level2Signature;
+
+        byte[] signature = level2Signature;
 		try {
 			if (sig.verify(signature)){
 				return Constants.LEVEL2_VALIDATION_OK;
@@ -330,13 +328,11 @@ public class SimpleDynamicFrame implements IDynamicFrame {
 			
 		} catch (SignatureException e) {
 			return Constants.LEVEL1_VALIDATION_SIG_ALG_NOT_IMPLEMENTED;
-		} catch (IllegalArgumentException e) {
-			return Constants.LEVEL1_VALIDATION_ENCODING_ERROR;
-		} catch (UnsupportedOperationException e) {
+		} catch (IllegalArgumentException | UnsupportedOperationException e) {
 			return Constants.LEVEL1_VALIDATION_ENCODING_ERROR;
 		}
-		
-		try {
+
+        try {
 			if (sig.verify(signature)){
 				return Constants.LEVEL1_VALIDATION_OK;
 			} else {
@@ -391,13 +387,9 @@ public class SimpleDynamicFrame implements IDynamicFrame {
 	 */
 	@Override
 	public void addDynamicContent(IUicDynamicContent content) throws EncodingFormatException {
-				
 		level2Data.setLevel2Data(new SimpleData());
-		
-		level2Data.getLevel2Data().setFormat(DynamicContentCoder.dynamicContentDataFDC1);
-			
-		level2Data.getLevel2Data().setData(DynamicContentCoder.encode(content, DynamicContentCoder.dynamicContentDataFDC1));
-		
+		level2Data.getLevel2Data().setFormat(Constants.DATA_TYPE_FDC_VERSION_1);
+		level2Data.getLevel2Data().setData(DynamicContentCoder.encode(content, Constants.DATA_TYPE_FDC_VERSION_1));
 	}
 	
 	/**
@@ -417,14 +409,13 @@ public class SimpleDynamicFrame implements IDynamicFrame {
 	 */
 	@Override
 	public IUicDynamicContent getDynamicContent() {
-		
-		if (this.getLevel2Data() == null || 
-				this.getLevel2Data().getLevel2Data() == null){
-				return null;
-		}
-		
+        if (this.getLevel2Data() == null)
+            return null;
+        if (this.getLevel2Data().getLevel2Data() == null)
+            return null;
+        if (!this.getLevel2Data().getLevel2Data().getFormat().equals(Constants.DATA_TYPE_FDC_VERSION_1))
+            return null;
 		return DynamicContentCoder.decode(level2Data.getLevel2Data().getData());
-			
 	}
 	
 

--- a/src/main/java/org/uic/barcode/dynamicFrame/v1/DynamicFrame.java
+++ b/src/main/java/org/uic/barcode/dynamicFrame/v1/DynamicFrame.java
@@ -10,6 +10,7 @@ import org.uic.barcode.asn1.uper.UperEncoder;
 import org.uic.barcode.dynamicContent.api.DynamicContentCoder;
 import org.uic.barcode.dynamicContent.api.IUicDynamicContent;
 import org.uic.barcode.dynamicContent.fdc1.UicDynamicContentDataFDC1;
+import org.uic.barcode.dynamicFrame.Constants;
 import org.uic.barcode.ticket.EncodingFormatException;
 
 
@@ -19,7 +20,7 @@ import org.uic.barcode.ticket.EncodingFormatException;
  * Implementation of the Draft under discussion, not final.
  */
 @Sequence
-public class DynamicFrame extends Object{
+public class DynamicFrame {
 	
 	/**
 	 * Instantiates a new dynamic frame.
@@ -126,14 +127,9 @@ public class DynamicFrame extends Object{
 	 * @throws EncodingFormatException the encoding format exception
 	 */
 	public void addDynamicContent(IUicDynamicContent content) throws EncodingFormatException {
-		
-		
 		level2SignedData.setLevel2Data(new DataType());
-		
-		level2SignedData.getLevel2Data().setFormat(DynamicContentCoder.dynamicContentDataFDC1);
-			
-		level2SignedData.getLevel2Data().setByteData(DynamicContentCoder.encode(content, DynamicContentCoder.dynamicContentDataFDC1));
-		
+		level2SignedData.getLevel2Data().setFormat(Constants.DATA_TYPE_FDC_VERSION_1);
+		level2SignedData.getLevel2Data().setByteData(DynamicContentCoder.encode(content, Constants.DATA_TYPE_FDC_VERSION_1));
 	}
 	
 	/**
@@ -154,14 +150,13 @@ public class DynamicFrame extends Object{
 	 * @return the dynamic content
 	 */
 	public IUicDynamicContent getDynamicContent() {
-		
-		if (level2SignedData == null || 
-		    level2SignedData.getLevel2Data() == null){
-				return null;
-		}
-		
-		return DynamicContentCoder.decode(this.getLevel2SignedData().getLevel2Data().getByteData());
-			
+        if (level2SignedData == null)
+            return null;
+        if (level2SignedData.getLevel2Data() == null)
+            return null;
+        if (!level2SignedData.getLevel2Data().getFormat().equals(Constants.DATA_TYPE_FDC_VERSION_1))
+            return null;
+        return DynamicContentCoder.decode(level2SignedData.getLevel2Data().getByteData());
 	}
 	
 	/**


### PR DESCRIPTION
The `getDynamicContent` method didn't actually check that the data type of the level 2 was actually set to `FDC1` before blindly passing it into `DynamicContentCoder.decode`. This would cause us compatibility problems down the road whenever `FDC2` starts getting rolled out. This PR fixes that.